### PR TITLE
Allow numbers in routing keys

### DIFF
--- a/lib/generate-exchange-json-schema.js
+++ b/lib/generate-exchange-json-schema.js
@@ -81,7 +81,7 @@ function generateBinding (type) {
     jsonSchema.properties.routingPattern = {
       description: 'Direct binding routing key',
       type: 'string',
-      pattern: '^[a-zA-Z]+(.[a-zA-Z]+)*$'
+      pattern: '^[a-zA-Z0-9]+(.[a-zA-Z0-9]+)*$'
     }
     // additional required properties
     jsonSchema.required.push('routingPattern')
@@ -94,7 +94,7 @@ function generateBinding (type) {
     jsonSchema.properties.routingPattern = {
       description: 'Direct binding routing key',
       type: 'string',
-      pattern: '^(([a-zA-Z]+|[*])\.)*([a-zA-Z]+|[*#])(\.([a-zA-Z]+|[*]))*$'
+      pattern: '^(([a-zA-Z0-9]+|[*])\.)*([a-zA-Z0-9]+|[*#])(\.([a-zA-Z0-9]+|[*]))*$'
     }
     // additional required properties
     jsonSchema.required.push('routingPattern')


### PR DESCRIPTION
Is there a reason the routing key formats are so strict? I'd like to be able to validate schemas in which routing keys can be auto-generated (in my case UUID V4 without the dashes).

I'm trying to work out in which case numbers would cause issues but I haven't found anything yet.

Example routing key: application1.91aef022e726400a87ac00e904c9c78d.